### PR TITLE
Fix/dremio 20 uses different col names for reflections

### DIFF
--- a/dbt/include/dremio/macros/adapters.sql
+++ b/dbt/include/dremio/macros/adapters.sql
@@ -164,7 +164,7 @@
 
 {% macro dremio__list_relations_without_caching(schema_relation) %}
   {% set check_column_name_query %}
-  -- Dremio 22 uses "dataset_name" instead of "dataset" on sys.reflections
+  -- Dremio 20 uses "dataset_name" instead of "dataset" on sys.reflections
   select 
     case when count(column_name) = 1
       then 'dataset'

--- a/dbt/include/dremio/macros/adapters.sql
+++ b/dbt/include/dremio/macros/adapters.sql
@@ -176,6 +176,7 @@
     and column_name  = 'dataset'
   {% endset %}
   {% set dataset_col = run_query(check_column_name_query).columns[0].values()[0] %}
+  {% set reflection_col = 'name' if dataset_col == 'dataset' else 'reflection_name' %}
   {% call statement('list_relations_without_caching', fetch_result=True) -%}
     with t1(table_catalog, table_name, table_schema, table_type) as (
     select lower(case when position('.' in table_schema) > 0
@@ -201,7 +202,7 @@
                 else strpos({{ dataset_col }}, '.') - 1
             end
             ,{{ dataset_col }}
-            ,name
+            ,{{ reflection_col }}
             ,type
         from sys.reflections
     )

--- a/dbt/include/dremio/macros/adapters.sql
+++ b/dbt/include/dremio/macros/adapters.sql
@@ -27,7 +27,26 @@
   )
 {% endmacro %}
 
+{% macro dremio__lookup_reflection_columns() -%}
+  {% set check_column_name_query %}
+    -- Dremio 20 uses "dataset_name" instead of "dataset" on sys.reflections
+    select 
+      case when count(column_name) = 1
+        then 'dataset'
+        else 'dataset_name'
+      end 
+    from information_schema.columns
+    where table_schema = 'sys'
+      and table_name   = 'reflections'
+      and column_name  = 'dataset'
+  {% endset %}
+  {{ return(run_query(check_column_name_query).columns[0].values()[0]) }}
+{%- endmacro %}
+
 {% macro dremio__get_columns_in_relation(relation) -%}
+  {% set dataset_col = dremio__lookup_reflection_columns() %}
+  {% set reflection_col = 'reflection_name' if dataset_col == 'dataset_name' else 'name' %}
+  {% set display_col = 'display_columns' if dataset_col == 'dataset_name' else 'displayColumns' %}
   {% call statement('get_columns_in_relation', fetch_result=True) %}
     with cols as (
       select lower(case when position('.' in table_schema) > 0
@@ -56,7 +75,7 @@
                   then substring(table_schema, position('.' in table_schema) + 1)
                   else 'no_schema'
               end)
-          ,lower(name)
+          ,lower({{ reflection_col }})
           ,lower(column_name)
           ,lower(data_type)
           ,character_maximum_length
@@ -65,8 +84,8 @@
           ,ordinal_position
       from sys.reflections
       join information_schema.columns
-          on (columns.table_schema || '.' || columns.table_name = replace(dataset, '"', '')
-              and (strpos(',' || replace(displayColumns, ' ', '') || ',', ',' || column_name || ',') > 0
+          on (columns.table_schema || '.' || columns.table_name = replace({{ dataset_col }}, '"', '')
+              and (strpos(',' || replace({{ display_col }}, ' ', '') || ',', ',' || column_name || ',') > 0
                   or strpos(',' || replace(dimensions, ' ', '') || ',', ',' || column_name || ',') > 0
                   or strpos(',' || replace(measures, ' ', '') || ',', ',' || column_name || ',') > 0))
     )
@@ -163,20 +182,8 @@
 {% endmacro %}
 
 {% macro dremio__list_relations_without_caching(schema_relation) %}
-  {% set check_column_name_query %}
-  -- Dremio 20 uses "dataset_name" instead of "dataset" on sys.reflections
-  select 
-    case when count(column_name) = 1
-      then 'dataset'
-      else 'dataset_name'
-    end 
-  from information_schema.columns
-  where table_schema = 'sys'
-    and table_name   = 'reflections'
-    and column_name  = 'dataset'
-  {% endset %}
-  {% set dataset_col = run_query(check_column_name_query).columns[0].values()[0] %}
-  {% set reflection_col = 'name' if dataset_col == 'dataset' else 'reflection_name' %}
+  {% set dataset_col = dremio__lookup_reflection_columns() %}
+  {% set reflection_col = 'reflection_name' if dataset_col == 'dataset_name' else 'name' %}
   {% call statement('list_relations_without_caching', fetch_result=True) -%}
     with t1(table_catalog, table_name, table_schema, table_type) as (
     select lower(case when position('.' in table_schema) > 0


### PR DESCRIPTION
Hi @fabrice-etanchaud ,

I'm in the process of migrating an older version of Dremio (4.9) to the latest version (20.1 Enterprise Edition).  I successfully migrated our VDS definitions into dbt models, and everything ran smoothly until I pointed at the new version.  

I identified the issue as a change in the `sys.reflections` column names, which impacts the initial `dremio__list_relations_without_caching` macro that is run before running any actual models. 

This is a backwards compatible fix that uses dbt's `run_query` macro to lookup the column names on `sys.reflections` from the `information_schema` and determine the proper column names to use.  If the `dataset` column exists on `sys.reflections` it defaults to the original column names you implemented (`dataset` and `name`).  If it does not exist, then it uses the new names (`dataset_name` and `reflection_name`). 

I have tested this on both the old 4.9 instance and the new 20.1 instance after implementing this fix successfully.  Happy to make an additional updates if you think they're necessary. 

Aaron