### PR TITLE
fix: use CONCAT instead of CONCAT_WS to avoid unsupported behavior on…

### DIFF
--- a/dbt/include/dremio/macros/adapters/metadata.sql
+++ b/dbt/include/dremio/macros/adapters/metadata.sql
@@ -31,13 +31,13 @@
         ,column_name
         ,ordinal_position as column_index
         ,lower(data_type) as column_type
-        ,concat_ws(', ',
+        ,concat(
         case when strpos(regexp_replace(display_columns, '$|, |^', '/'), '/' || column_name || '/') > 0 then 'display' end
-        ,case when strpos(regexp_replace(dimensions, '$|, |^', '/'), '/' || column_name || '/') > 0 then 'dimension'  end
-        ,case when strpos(regexp_replace(measures, '$|, |^', '/'), '/' || column_name || '/') > 0 then 'measure'  end
-        ,case when strpos(regexp_replace(sort_columns, '$|, |^', '/'), '/' || column_name || '/') > 0 then 'sort'  end
-        ,case when strpos(regexp_replace(partition_columns, '$|, |^', '/'), '/' || column_name || '/') > 0 then 'partition'  end
-        ,case when strpos(regexp_replace(distribution_columns, '$|, |^', '/'), '/' || column_name || '/') > 0 then 'distribution' end
+        ,', ',case when strpos(regexp_replace(dimensions, '$|, |^', '/'), '/' || column_name || '/') > 0 then 'dimension'  end
+        ,', ',case when strpos(regexp_replace(measures, '$|, |^', '/'), '/' || column_name || '/') > 0 then 'measure'  end
+        ,', ',case when strpos(regexp_replace(sort_columns, '$|, |^', '/'), '/' || column_name || '/') > 0 then 'sort'  end
+        ,', ',case when strpos(regexp_replace(partition_columns, '$|, |^', '/'), '/' || column_name || '/') > 0 then 'partition'  end
+        ,', ',case when strpos(regexp_replace(distribution_columns, '$|, |^', '/'), '/' || column_name || '/') > 0 then 'distribution' end
         ) as column_comment
         ,cast(null as varchar) as table_owner
       from sys.reflections


### PR DESCRIPTION
Hi @fabrice-etanchaud ,

Thanks for the recent updates on the plugin for Dremio!   This is a small update to the `dremio__get_catalog` macro to support AWSE metadata lookups when running with reflections enabled.  After some conversations with the Dremio support folks, they informed me that `CONCAT_WS` is not supported on AWSE due to a missing Hive library.  

This simply changes the `CONCAT_WS` function to a `CONCAT` with multiple `', '` separators.  

Aaron